### PR TITLE
Use LiteralPaths for Get-ShortName

### DIFF
--- a/Functions/Get-ShortName.ps1
+++ b/Functions/Get-ShortName.ps1
@@ -57,12 +57,12 @@ function Get-ShortName {
 
     process {
         foreach ($curPath in $Path) {
-            if (Test-Path -Path $curPath) {
-                $ResolveFile = Resolve-Path -Path $curPath
+            if (Test-Path -LiteralPath $curPath) {
+                $ResolveFile = Resolve-Path -LiteralPath $curPath
                 if ($ResolveFile.count -gt 1) {
                     Write-Error -Message "ERROR: File specification [$curPath] resolves to more than 1 file."
                 } else {
-                    $Item = Get-Item -Path $ResolveFile
+                    $Item = Get-Item -LiteralPath $ResolveFile
                     if ($Item.PSProvider.ToString() -eq 'Microsoft.PowerShell.Core\FileSystem') {
                         Write-Verbose -Message "Using item [$ResolveFile]"
                         if ($Item.PSIsContainer) {


### PR DESCRIPTION
Without this, filenames with certain Unicode characters (e.g. `꞉`  [[char]0xA789](https://www.fileformat.info/info/unicode/char/a789/index.htm)) will erroneously receive the error that the file doesn't exist.